### PR TITLE
Simplification via removal of SystemType

### DIFF
--- a/src/App/main.cpp
+++ b/src/App/main.cpp
@@ -70,11 +70,11 @@ int main(int argc, char **argv) {
     Scene & scene(*engine.scene());
 
     /* Create camera and camera controller components */
-    GameObject & camera(*scene.createGameObject());
-    CameraComponent & cc(*scene.createComponent<CameraComponent>(45.f, 1280.f / 960.f, 0.01f, 250.f));
+    GameObject & camera(scene.createGameObject());
+    CameraComponent & cc(scene.createComponent<CameraComponent>(45.f, 1280.f / 960.f, 0.01f, 250.f));
     camera.addComponent(cc);
-    camera.addComponent(*scene.createComponent<CameraController>(cc, 0.2f, 15.f, GLFW_KEY_W, GLFW_KEY_S, GLFW_KEY_A, GLFW_KEY_D, GLFW_KEY_SPACE, GLFW_KEY_LEFT_SHIFT));
-    camera.addComponent(*scene.createComponent<SpatialComponent>());
+    camera.addComponent(scene.createComponent<CameraController>(cc, 0.2f, 15.f, GLFW_KEY_W, GLFW_KEY_S, GLFW_KEY_A, GLFW_KEY_D, GLFW_KEY_SPACE, GLFW_KEY_LEFT_SHIFT));
+    camera.addComponent(scene.createComponent<SpatialComponent>());
     camera.getSpatial()->setPosition(glm::vec3(-4.0f, 0.0f, 0.0f));
 
     /* Create diffuse shader */
@@ -93,13 +93,13 @@ int main(int argc, char **argv) {
     }
 
     /* Create bunny */
-    GameObject & bunny(*scene.createGameObject());
-    bunny.addComponent(*scene.createComponent<SpatialComponent>(
+    GameObject & bunny(scene.createGameObject());
+    bunny.addComponent(scene.createComponent<SpatialComponent>(
         glm::vec3(0.0f, 0.0f, 0.0f), // position
         glm::vec3(1.0f, 1.0f, 1.0f), // scale
         glm::mat3() // rotation
     ));
-    bunny.addComponent(*scene.createComponent<DiffuseRenderComponent>(
+    bunny.addComponent(scene.createComponent<DiffuseRenderComponent>(
         scene.renderSystem().shaders.find("diffuse")->second->pid,
         *engine.loader.getMesh("bunny.obj"),
         ModelTexture(0.3f, glm::vec3(0.f, 0.f, 1.f), glm::vec3(1.f))));
@@ -107,6 +107,8 @@ int main(int argc, char **argv) {
 
     /* Main loop */
     engine.run();
+
+    scene.shutDown();
 
     return EXIT_SUCCESS;
 }

--- a/src/Engine/Scene/Scene.cpp
+++ b/src/Engine/Scene/Scene.cpp
@@ -18,19 +18,14 @@ Scene::Scene() :
     m_componentKillQueue()
 {
     /* Instantiate systems */
-    m_componentRefs[System::GAMELOGIC].reset(new std::vector<Component *>());
-    m_gameLogicSystemRef = Depot<GameLogicSystem>::add(new GameLogicSystem(*m_componentRefs[System::GAMELOGIC].get()));
-
-    m_componentRefs[System::RENDER].reset(new std::vector<Component *>());
-    m_renderSystemRef = Depot<RenderSystem>::add(new RenderSystem(*m_componentRefs[System::RENDER].get()));
-    
-    m_componentRefs[System::SPATIAL].reset(new std::vector<Component *>());
-    m_spatialSystemRef = Depot<SpatialSystem>::add(new SpatialSystem(*m_componentRefs[System::SPATIAL].get()));
+    m_gameLogicSystemRef = Depot<GameLogicSystem>::add(new GameLogicSystem(sysComponentRefs<GameLogicSystem>()));
+    m_renderSystemRef = Depot<RenderSystem>::add(new RenderSystem(sysComponentRefs<RenderSystem>()));    
+    m_spatialSystemRef = Depot<SpatialSystem>::add(new SpatialSystem(sysComponentRefs<SpatialSystem>()));
 }
 
-GameObject * Scene::createGameObject() {
+GameObject & Scene::createGameObject() {
     m_gameObjectInitQueue.emplace_back(new GameObject());
-    return m_gameObjectInitQueue.back().get();
+    return *m_gameObjectInitQueue.back().get();
 }
 
 void Scene::update(float dt) {
@@ -44,6 +39,8 @@ void Scene::update(float dt) {
     doKillQueue();
 }
 
+#include <iostream>
+
 void Scene::doInitQueue() {
     for (auto & o : m_gameObjectInitQueue) {
         m_gameObjectRefs.push_back(Depot<GameObject>::add(o.release()));
@@ -51,18 +48,15 @@ void Scene::doInitQueue() {
     m_gameObjectInitQueue.clear();
 
     for (auto & p : m_componentInitQueue) {
-        System::Type sys(p.first);
-        std::vector<std::unique_ptr<Component>> & comps(p.second);
+        std::vector<std::unique_ptr<Component>> & initComps(p.second);
+        auto & compRefs(m_componentRefs.at(p.first));
 
-        auto & compRefs(m_componentRefs[sys]);
-        if (!compRefs) compRefs.reset(new std::vector<Component *>());
-
-        for (auto & comp : comps) {
+        for (auto & comp : initComps) {
             compRefs->push_back(Depot<Component>::add(comp.release()));
             compRefs->back()->init();
         }
         
-        comps.clear();
+        initComps.clear();
     }
 }
 
@@ -89,15 +83,11 @@ void Scene::doKillQueue() {
     m_gameObjectKillQueue.clear();
 
     for (auto sysIt(m_componentKillQueue.begin()); sysIt != m_componentKillQueue.end(); ++sysIt) {
-        System::Type sys(sysIt->first);
-        std::vector<Component *> & killComps(sysIt->second);
-
-        if (!m_componentRefs[sys].get()) {
-            continue;
-        }
+        std::type_index sysIndex(sysIt->first);
+        auto & killComps(sysIt->second);
 
         for (auto killIt(killComps.begin()); killIt != killComps.end(); ++killIt) {
-            std::vector<Component *> & compRefs(*m_componentRefs[sys]);
+            auto & compRefs(*m_componentRefs.at(sysIndex));
             bool found(false);
             for (auto refIt(compRefs.begin()); refIt != compRefs.end(); ++refIt) {
                 if (*refIt == *killIt) {
@@ -106,10 +96,11 @@ void Scene::doKillQueue() {
                     break;
                 }
             }
-            if (!found) {
-                for (auto initIt(m_componentInitQueue[sys].begin()); initIt != m_componentInitQueue[sys].end(); ++initIt) {
+            if (!found && m_componentInitQueue.count(sysIndex)) {
+                auto & initRefs(m_componentInitQueue.at(sysIndex));
+                for (auto initIt(initRefs.begin()); initIt != initRefs.end(); ++initIt) {
                     if (initIt->get() == *killIt) {
-                        m_componentInitQueue[sys].erase(initIt);
+                        initRefs.erase(initIt);
                         break;
                     }
                 }

--- a/src/Engine/Scene/Scene.cpp
+++ b/src/Engine/Scene/Scene.cpp
@@ -39,8 +39,6 @@ void Scene::update(float dt) {
     doKillQueue();
 }
 
-#include <iostream>
-
 void Scene::doInitQueue() {
     for (auto & o : m_gameObjectInitQueue) {
         m_gameObjectRefs.push_back(Depot<GameObject>::add(o.release()));

--- a/src/Engine/System/GameLogicSystem.hpp
+++ b/src/Engine/System/GameLogicSystem.hpp
@@ -8,10 +8,6 @@ class GameLogicSystem : public System {
 
     public:
 
-    constexpr static Type type = GAMELOGIC;
-
-    public:
-
     GameLogicSystem(std::vector<Component *> & components);
 
 };

--- a/src/Engine/System/RenderSystem.hpp
+++ b/src/Engine/System/RenderSystem.hpp
@@ -14,10 +14,6 @@ class RenderSystem : public System {
 
     public:
 
-    constexpr static Type type = RENDER;
-
-    public:
-
         RenderSystem(std::vector<Component *> & components);
 
         /* If the shader already exists, return it

--- a/src/Engine/System/SpatialSystem.hpp
+++ b/src/Engine/System/SpatialSystem.hpp
@@ -6,10 +6,6 @@ class SpatialSystem : public System {
 
     public:
 
-    constexpr static Type type = SPATIAL;
-
-    public:
-
     SpatialSystem(const std::vector<Component *> & comps);
 
 };

--- a/src/Engine/System/System.hpp
+++ b/src/Engine/System/System.hpp
@@ -16,14 +16,6 @@ class System {
 
     public:
 
-    enum Type {
-        GAMELOGIC,
-        RENDER,
-        SPATIAL
-    };
-
-    public:
-
         System(const std::vector<Component *> & components);
 
         /* Generic update function */


### PR DESCRIPTION
further simplified the scene/system/component situation by doing away with the SystemType enum altogether. The scene now internally uses the type_index of the system as the map key. This also allows the ability to add pre-created components to the scene, which i've implemented as well. This is necessary in the case of collision, as you want the program to generate a certain kind of bounding shape that isn't necesarily known at compile time.